### PR TITLE
[SAR-450] 文字コード変更対応

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -17,6 +17,9 @@ default-character-set          = <%= @config.charset %>
 <% end %>
 
 [mysqld]
+<% if @config.charset %>
+character-set-server           = <%= @config.charset %>
+<% end %>
 <% if @config.run_user %>
 user                           = <%= @config.run_user %>
 <% end %>


### PR DESCRIPTION
- v5.5以降は[mysqld]配下にcharater-set-serverを設定する必要があるため、その対応